### PR TITLE
テスティングペアを探すときに、今のプロジェクトだけから探すパッチ

### DIFF
--- a/junit.extensions.eclipse.quick/src/junit/extensions/eclipse/quick/OpenTestingPairAction.java
+++ b/junit.extensions.eclipse.quick/src/junit/extensions/eclipse/quick/OpenTestingPairAction.java
@@ -190,7 +190,7 @@ public class OpenTestingPairAction extends QuickJUnitAction {
     }
 
     private List findPairTypes(String[] pairNames) throws JavaModelException {
-        IJavaProject[] projects = getJavaProjects();
+        IJavaProject[] projects = new IJavaProject[]{getCompilationUnitOfJavaEditor().getJavaProject()};
         Set result = new LinkedHashSet();
         for (int i = 0; i < projects.length; ++i) {
             IJavaProject project = projects[i];


### PR DESCRIPTION
はじめまして。

今のquick-junitではワークスペースにある全部のプロジェクトからテスティングペアを探して、対象が複数あった場合一覧で候補を出すようになってます。

色々なブランチを同じワークスペースに置いて作業していると、同じFQCNのクラスが複数のプロジェクトに存在することになって、別のブランチのテスティングペアまで候補として表示されてしまいます。

これでは嬉しくありません。
そこでSummaryの修正をしてみました。

よろしければ取り込んでくださいませ。
